### PR TITLE
Add simulation, partial insert/extract, and explicit capacity to fluid containers

### DIFF
--- a/src/main/java/io/github/prospector/silk/fluid/FluidContainer.java
+++ b/src/main/java/io/github/prospector/silk/fluid/FluidContainer.java
@@ -1,27 +1,99 @@
 package io.github.prospector.silk.fluid;
 
+import io.github.prospector.silk.util.ContainerInteraction;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.util.math.Direction;
 
 public interface FluidContainer {
+
+	int getMaxCapacity();
+
+	default int getCurrentFill(Direction fromSide) {
+		int amount = 0;
+		for (FluidInstance inst : getFluids(fromSide)) {
+			amount += inst.amount;
+		}
+		return amount;
+	}
+
+	default int getCurrentSingleFluidFill(Direction fromSide, Fluid fluid) {
+		int amount = 0;
+		for (FluidInstance inst : getFluids(fromSide)) {
+			if (inst.fluid == fluid) amount += inst.amount;
+		}
+		return amount;
+	}
+
 	boolean canInsertFluid(Direction fromSide, Fluid fluid, int amount);
 
 	boolean canExtractFluid(Direction fromSide, Fluid fluid, int amount);
 
-	default boolean tryInsertFluid(Direction fromSide, Fluid fluid, int amount) {
+	/**
+	 * Attempt to insert fluid on an all-or-nothing basis.
+	 * @param fromSide the side from which to insert.
+	 * @param fluid the type of fluid to insert.
+	 * @param amount how much fluid to insert.
+	 * @param interaction whether to SIMULATE or EXECUTE insertion.
+	 * @return whether the insertion was/would be successful.
+	 */
+	default boolean tryInsertFluid(Direction fromSide, Fluid fluid, int amount, ContainerInteraction interaction) {
 		if (canInsertFluid(fromSide, fluid, amount)) {
-			insertFluid(fromSide, fluid, amount);
+			if (interaction == ContainerInteraction.EXECUTE) insertFluid(fromSide, fluid, amount);
 			return true;
 		}
 		return false;
 	}
 
-	default boolean tryExtractFluid(Direction fromSide, Fluid fluid, int amount) {
+	/**
+	 * Attempt to insert fluid, only filling partially if the container can't hold all the fluid.
+	 * @param fromSide the side from which to insert.
+	 * @param fluid the type of fluid to insert.
+	 * @param maxAmount how much fluid to insert at maximum.
+	 * @param interaction whether to SIMULATE or EXECUTE insertion.
+	 * @return an integer amount of how much fluid was/would be moved.
+	 */
+	default int tryPartialInsertFluid(Direction fromSide, Fluid fluid, int maxAmount, ContainerInteraction interaction) {
+		int remainingCapacity = getMaxCapacity() - getCurrentFill(fromSide);
+		int amount = maxAmount <= remainingCapacity ? maxAmount : remainingCapacity;
+		if (canInsertFluid(fromSide, fluid, amount)) {
+			if (interaction == ContainerInteraction.EXECUTE) insertFluid(fromSide, fluid, amount);
+			return amount;
+		}
+		return 0;
+	}
+
+	/**
+	 * Attempt to extract fluid on an all-or-nothing basis.
+	 * @param fromSide the side from which to extract.
+	 * @param fluid the type of fluid to extract.
+	 * @param amount how much fluid to extract.
+	 * @param interaction whether to SIMULATE or EXECUTE extraction.
+	 * @return whether the extraction was/would be successful.
+	 */
+	default boolean tryExtractFluid(Direction fromSide, Fluid fluid, int amount, ContainerInteraction interaction) {
 		if (canExtractFluid(fromSide, fluid, amount)) {
-			extractFluid(fromSide, fluid, amount);
+			if (interaction == ContainerInteraction.EXECUTE) extractFluid(fromSide, fluid, amount);
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Attempt to extract fluid, only emptying partially if the container doesn't have enough fluid.
+	 * @param fromSide the side from which to extract.
+	 * @param fluid the type of fluid to extract.
+	 * @param maxAmount how much fluid to extract at maximum.
+	 * @param interaction whether to SIMULATE or EXECUTE extraction.
+	 * @return an integer amount of how much fluid was/would be moved.
+	 */
+	default int tryPartialExtractFluid(Direction fromSide, Fluid fluid, int maxAmount, ContainerInteraction interaction) {
+		int remainingFluid = getCurrentSingleFluidFill(fromSide, fluid);
+		int amount = maxAmount <= remainingFluid ? maxAmount : remainingFluid;
+		if (canExtractFluid(fromSide, fluid, amount)) {
+			if (interaction == ContainerInteraction.EXECUTE) extractFluid(fromSide, fluid, amount);
+			return amount;
+		}
+		return 0;
 	}
 
 	void insertFluid(Direction fromSide, Fluid fluid, int amount);

--- a/src/main/java/io/github/prospector/silk/util/ContainerInteraction.java
+++ b/src/main/java/io/github/prospector/silk/util/ContainerInteraction.java
@@ -1,0 +1,9 @@
+package io.github.prospector.silk.util;
+
+public enum ContainerInteraction {
+	/**
+	 * @value Simulate: pretend to interact and return what would be returned if actually attempted
+	 * @value Execute: actually attempt interaction, affecting the container
+	 */
+	EXECUTE, SIMULATE
+}


### PR DESCRIPTION
## Why?

Right now, fluids can only be inserted/extracted in exact amounts, and have no lenience for partial fills/empties. Either the interaction fits inside the current container, or it fails. On top of that, any insertion or extraction is final; there's no way to check beforehand if an insertion or extraction will work before you actually try it. Lastly, there's also no standard way for an external system to query the maximum capacity of a container, and an external system must manually iterate through all the visible fluids to calculate the current fill amount (which some fluid containers might not want).

## What does this do?

This PR solves all of these issues in the following ways:
- adds `tryPartialInsertFluid` and `tryPartialExtractFluid`, which will only fill/empty the maximum amount the container has access to. Each returns how much fluid was successfully moved, in the form of an integer. The original `tryInsertFluid` and `tryExtractFluid` are still in place, in case something needs to be strict. Javadocs are added for all four methods, so that it's easy to understand what each does.
- adds a ContainerInteraction enum, with the values `SIMULATE` and `EXECUTE`. When the enum is set to `EXECUTE`, the container will actually be changed, and when the enum is set to `SIMULATE`, it will only calculate the hypothetical result without affecting the container's real contents. This can also be used if Silk ever adds item or energy handling, or by any other handling API.
- adds methods for getting the max capacity of a container, getting the current fill amount of a container, and getting the current amount of a single Fluid type.