### PR TITLE
ContainerInteraction -> ActionType

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.8
 
 group = "io.github.prospector.silk"
 archivesBaseName = "SilkAPI"
-version = "1.0.0"
+version = "1.1.0"
 
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {

--- a/src/main/java/io/github/prospector/silk/fluid/FluidContainer.java
+++ b/src/main/java/io/github/prospector/silk/fluid/FluidContainer.java
@@ -1,6 +1,6 @@
 package io.github.prospector.silk.fluid;
 
-import io.github.prospector.silk.util.ContainerInteraction;
+import io.github.prospector.silk.util.ActionType;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.util.math.Direction;
 
@@ -37,9 +37,9 @@ public interface FluidContainer {
 	 * @param interaction whether to SIMULATE or EXECUTE insertion.
 	 * @return whether the insertion was/would be successful.
 	 */
-	default boolean tryInsertFluid(Direction fromSide, Fluid fluid, int amount, ContainerInteraction interaction) {
+	default boolean tryInsertFluid(Direction fromSide, Fluid fluid, int amount, ActionType interaction) {
 		if (canInsertFluid(fromSide, fluid, amount)) {
-			if (interaction == ContainerInteraction.EXECUTE) insertFluid(fromSide, fluid, amount);
+			if (interaction == ActionType.PERFORM) insertFluid(fromSide, fluid, amount);
 			return true;
 		}
 		return false;
@@ -54,11 +54,11 @@ public interface FluidContainer {
 	 * @param interaction whether to SIMULATE or EXECUTE insertion.
 	 * @return an integer amount of how much fluid was/would be moved.
 	 */
-	default int tryPartialInsertFluid(Direction fromSide, Fluid fluid, int maxAmount, ContainerInteraction interaction) {
+	default int tryPartialInsertFluid(Direction fromSide, Fluid fluid, int maxAmount, ActionType interaction) {
 		int remainingCapacity = getMaxCapacity() - getCurrentFill(fromSide);
 		int amount = maxAmount <= remainingCapacity ? maxAmount : remainingCapacity;
 		if (canInsertFluid(fromSide, fluid, amount)) {
-			if (interaction == ContainerInteraction.EXECUTE) insertFluid(fromSide, fluid, amount);
+			if (interaction == ActionType.PERFORM) insertFluid(fromSide, fluid, amount);
 			return amount;
 		}
 		return 0;
@@ -73,9 +73,9 @@ public interface FluidContainer {
 	 * @param interaction whether to SIMULATE or EXECUTE extraction.
 	 * @return whether the extraction was/would be successful.
 	 */
-	default boolean tryExtractFluid(Direction fromSide, Fluid fluid, int amount, ContainerInteraction interaction) {
+	default boolean tryExtractFluid(Direction fromSide, Fluid fluid, int amount, ActionType interaction) {
 		if (canExtractFluid(fromSide, fluid, amount)) {
-			if (interaction == ContainerInteraction.EXECUTE) extractFluid(fromSide, fluid, amount);
+			if (interaction == ActionType.PERFORM) extractFluid(fromSide, fluid, amount);
 			return true;
 		}
 		return false;
@@ -90,11 +90,11 @@ public interface FluidContainer {
 	 * @param interaction whether to SIMULATE or EXECUTE extraction.
 	 * @return an integer amount of how much fluid was/would be moved.
 	 */
-	default int tryPartialExtractFluid(Direction fromSide, Fluid fluid, int maxAmount, ContainerInteraction interaction) {
+	default int tryPartialExtractFluid(Direction fromSide, Fluid fluid, int maxAmount, ActionType interaction) {
 		int remainingFluid = getCurrentSingleFluidFill(fromSide, fluid);
 		int amount = maxAmount <= remainingFluid ? maxAmount : remainingFluid;
 		if (canExtractFluid(fromSide, fluid, amount)) {
-			if (interaction == ContainerInteraction.EXECUTE) extractFluid(fromSide, fluid, amount);
+			if (interaction == ActionType.PERFORM) extractFluid(fromSide, fluid, amount);
 			return amount;
 		}
 		return 0;

--- a/src/main/java/io/github/prospector/silk/util/ActionType.java
+++ b/src/main/java/io/github/prospector/silk/util/ActionType.java
@@ -1,9 +1,9 @@
 package io.github.prospector.silk.util;
 
-public enum ContainerInteraction {
+public enum ActionType {
 	/**
 	 * @value Simulate: pretend to interact and return what would be returned if actually attempted
 	 * @value Execute: actually attempt interaction, affecting the container
 	 */
-	EXECUTE, SIMULATE
+	PERFORM, SIMULATE
 }


### PR DESCRIPTION
This protocol has... well, nothing to do with Containers in the MCP or Yarn sense. I know this is already a breaking change, but I'd like to use this API a lot, and this would make things a lot more pleasant for me.