### PR TITLE
bump to 08a, add isEmpty and NBT for fluids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.8
 
 group = "io.github.prospector.silk"
 archivesBaseName = "SilkAPI"
-version = "1.2.0"
+version = "1.2.1"
 
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {

--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,10 @@ minecraft {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:18w50a"
-	mappings "net.fabricmc:yarn:18w50a.90"
-	modCompile "net.fabricmc:fabric-loader:0.3.2.91"
-	modCompile "net.fabricmc:fabric:0.1.3.68"
+	minecraft "com.mojang:minecraft:19w08b"
+	mappings "net.fabricmc:yarn:19w08b.3"
+	modCompile "net.fabricmc:fabric-loader:0.3.7.109"
+	modCompile "net.fabricmc:fabric:0.2.2.103"
 }
 
 processResources {

--- a/src/main/java/io/github/prospector/silk/block/InventoryBlock.java
+++ b/src/main/java/io/github/prospector/silk/block/InventoryBlock.java
@@ -1,0 +1,21 @@
+package io.github.prospector.silk.block;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.InventoryProvider;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SidedInventory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+
+public abstract class InventoryBlock extends SilkBlockWithEntity implements InventoryProvider {
+
+	public InventoryBlock(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public SidedInventory getInventory(BlockState state, IWorld world, BlockPos pos) {
+		if (!(world.getBlockEntity(pos) instanceof Inventory)) return null;
+		else return (SidedInventory) world.getBlockEntity(pos);
+	}
+}

--- a/src/main/java/io/github/prospector/silk/block/SilkLeavesBlock.java
+++ b/src/main/java/io/github/prospector/silk/block/SilkLeavesBlock.java
@@ -1,6 +1,6 @@
 package io.github.prospector.silk.block;
 
-import net.fabricmc.fabric.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.block.FabricBlockSettings;
 import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.Material;
 import net.minecraft.item.Item;
@@ -10,6 +10,6 @@ public class SilkLeavesBlock extends LeavesBlock {
 	public Item sapling;
 
 	public SilkLeavesBlock(Item sapling) {
-		super(FabricBlockSettings.create(Material.LEAVES).setHardness(0.2F).acceptRandomTicks().setSoundGroup(BlockSoundGroup.GRASS).build());
+		super(FabricBlockSettings.of(Material.LEAVES).hardness(0.2F).ticksRandomly().sounds(BlockSoundGroup.GRASS).build());
 	}
 }

--- a/src/main/java/io/github/prospector/silk/block/SilkSaplingBlock.java
+++ b/src/main/java/io/github/prospector/silk/block/SilkSaplingBlock.java
@@ -1,6 +1,6 @@
 package io.github.prospector.silk.block;
 
-import net.fabricmc.fabric.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.block.FabricBlockSettings;
 import net.minecraft.block.Material;
 import net.minecraft.block.SaplingBlock;
 import net.minecraft.sound.BlockSoundGroup;
@@ -8,6 +8,6 @@ import io.github.prospector.silk.util.SilkSaplingGenerator;
 
 public class SilkSaplingBlock extends SaplingBlock {
 	public SilkSaplingBlock(SilkSaplingGenerator treeGenerator) {
-		super(treeGenerator, FabricBlockSettings.create(Material.PLANT).setCollidable(false).acceptRandomTicks().setHardness(0).setSoundGroup(BlockSoundGroup.GRASS).build());
+		super(treeGenerator, FabricBlockSettings.of(Material.PLANT).collidable(false).ticksRandomly().hardness(0).sounds(BlockSoundGroup.GRASS).build());
 	}
 }

--- a/src/main/java/io/github/prospector/silk/blockentity/InventoryBlockEntity.java
+++ b/src/main/java/io/github/prospector/silk/blockentity/InventoryBlockEntity.java
@@ -85,32 +85,7 @@ public abstract class InventoryBlockEntity extends BlockEntity implements Invent
 	}
 
 	@Override
-	public int getInvProperty(int i) {
-		return 0;
-	}
-
-	@Override
-	public void setInvProperty(int i, int i1) {
-
-	}
-
-	@Override
-	public int getInvPropertyCount() {
-		return 0;
-	}
-
-	@Override
-	public void clearInv() {
+	public void clear() {
 		inventory.clear();
-	}
-
-	@Override
-	public TextComponent getName() {
-		return null;
-	}
-
-	@Override
-	public boolean hasCustomName() {
-		return false;
 	}
 }

--- a/src/main/java/io/github/prospector/silk/client/util/DrawingUtil.java
+++ b/src/main/java/io/github/prospector/silk/client/util/DrawingUtil.java
@@ -7,6 +7,6 @@ import net.minecraft.item.ItemStack;
 public class DrawingUtil {
 	public static void drawItemStack(ItemStack stack, int x, int y) {
 		GuiLighting.enableForItems();
-		MinecraftClient.getInstance().getItemRenderer().renderItemAndGlowInGui(stack, x, y);
+		MinecraftClient.getInstance().getItemRenderer().renderGuiItem(stack, x, y);
 	}
 }

--- a/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
+++ b/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
@@ -10,9 +10,13 @@ import net.minecraft.util.registry.Registry;
 public class FluidInstance implements TagSerializable {
 	public static final String FLUID_KEY = "Fluid";
 	public static final String AMOUNT_KEY = "Amount";
+	public static final String TAG_KEY = "Tag";
+
+	public static final FluidInstance EMPTY = new FluidInstance(Fluids.EMPTY, 0);
 
 	protected Fluid fluid;
 	protected int amount;
+	protected CompoundTag tag;
 
 	public FluidInstance(Fluid fluid, int amount) {
 		this.fluid = fluid;
@@ -40,6 +44,10 @@ public class FluidInstance implements TagSerializable {
 		return amount;
 	}
 
+	public CompoundTag getTag() {
+		return tag;
+	}
+
 	public FluidInstance setFluid(Fluid fluid) {
 		this.fluid = fluid;
 		return this;
@@ -60,6 +68,14 @@ public class FluidInstance implements TagSerializable {
 		return this;
 	}
 
+	public void setTag(CompoundTag tag) {
+		this.tag = tag;
+	}
+
+	public boolean isEmpty() {
+		return this.getFluid() == Fluids.EMPTY || this.getAmount() == 0;
+	}
+
 	public FluidInstance copy() {
 		return new FluidInstance().setFluid(fluid).setAmount(amount);
 	}
@@ -68,6 +84,7 @@ public class FluidInstance implements TagSerializable {
 	public CompoundTag toTag(CompoundTag tag) {
 		tag.putString(FLUID_KEY, Registry.FLUID.getId(fluid).toString());
 		tag.putInt(AMOUNT_KEY, amount);
+		tag.put(TAG_KEY, tag);
 		return tag;
 	}
 
@@ -75,6 +92,7 @@ public class FluidInstance implements TagSerializable {
 	public void fromTag(CompoundTag tag) {
 		fluid = Registry.FLUID.get(new Identifier(tag.getString(FLUID_KEY)));
 		amount = tag.getInt(AMOUNT_KEY);
+		tag = tag.getCompound(TAG_KEY);
 	}
 
 	@Override

--- a/src/main/java/io/github/prospector/silk/util/VoxelShapeUtil.java
+++ b/src/main/java/io/github/prospector/silk/util/VoxelShapeUtil.java
@@ -5,7 +5,7 @@ import net.minecraft.util.shape.VoxelShape;
 
 public class VoxelShapeUtil {
 	public static VoxelShape rotateHorizontal(int minX, int minY, int minZ, int maxX, int maxY, int maxZ, Rotation rot) {
-		return Block.createCubeShape(
+		return Block.createCuboidShape(
 			rot.getX(minX, minZ), rot.getX(maxX, maxZ), minY, maxY,
 			rot.getZ(minX, minZ), rot.getZ(maxX, maxZ)
 		);


### PR DESCRIPTION
- update to minecraft 19w08a, along with matching Fabric versions
- update `InventoryBlockEntity` for new `InventoryProvider` system and add `InventoryBlock` to match (I'm pretty sure I got it right? it looks like Mojang doesn't even use their own InventoryProvider in any blocks yet :thonkjang:)
- add an `isEmpty()` check to fluid instances, along with fluid NBT tags