### PR TITLE
Fix crash when saving to tags with null fluid NBT

### DIFF
--- a/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
+++ b/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
@@ -84,7 +84,9 @@ public class FluidInstance implements TagSerializable {
 	public CompoundTag toTag(CompoundTag tag) {
 		tag.putString(FLUID_KEY, Registry.FLUID.getId(fluid).toString());
 		tag.putInt(AMOUNT_KEY, amount);
-		tag.put(TAG_KEY, tag);
+		if (tag != null && !tag.isEmpty()) {
+			tag.put(TAG_KEY, tag);
+	    	}
 		return tag;
 	}
 
@@ -92,7 +94,9 @@ public class FluidInstance implements TagSerializable {
 	public void fromTag(CompoundTag tag) {
 		fluid = Registry.FLUID.get(new Identifier(tag.getString(FLUID_KEY)));
 		amount = tag.getInt(AMOUNT_KEY);
-		tag = tag.getCompound(TAG_KEY);
+		if (tag.containsKey(TAG_KEY)) {
+			tag = tag.getCompound(TAG_KEY);
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
+++ b/src/main/java/io/github/prospector/silk/fluid/FluidInstance.java
@@ -84,8 +84,8 @@ public class FluidInstance implements TagSerializable {
 	public CompoundTag toTag(CompoundTag tag) {
 		tag.putString(FLUID_KEY, Registry.FLUID.getId(fluid).toString());
 		tag.putInt(AMOUNT_KEY, amount);
-		if (tag != null && !tag.isEmpty()) {
-			tag.put(TAG_KEY, tag);
+		if (this.tag != null && !this.tag.isEmpty()) {
+			tag.put(TAG_KEY, this.tag);
 	    	}
 		return tag;
 	}
@@ -95,7 +95,7 @@ public class FluidInstance implements TagSerializable {
 		fluid = Registry.FLUID.get(new Identifier(tag.getString(FLUID_KEY)));
 		amount = tag.getInt(AMOUNT_KEY);
 		if (tag.containsKey(TAG_KEY)) {
-			tag = tag.getCompound(TAG_KEY);
+			this.tag = tag.getCompound(TAG_KEY);
 		}
 	}
 


### PR DESCRIPTION
This should fix crashes when you try to convert a `FluidInstance` to a `TagCompound` when the its own `TagCompound` is null. Currently this crashes the game because `FluidInstance#tag` is set to null by default.